### PR TITLE
Add support for python 3.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         #image: [quay.io/pypa/manylinux2014_x86_64, quay.io/pypa/manylinux2014_aarch64]
         image: [quay.io/pypa/manylinux2014_x86_64]
-        python-version: [cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310, cp311-cp311]
+        python-version: [cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310, cp311-cp311, cp312-cp312]
     env:
       pyo3-python: /opt/python/${{ matrix.python-version }}/bin/python
     steps:
@@ -53,6 +53,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -83,6 +84,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -111,10 +113,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install CI requirements
       run: python -m pip install -U -r ci/requirements.txt
     - name: Build source tarball with vendored sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
         - python-version: "3.11"
           python-release: v3.11
           python-impl: CPython
+        - python-version: "3.12"
+          python-release: v3.12
+          python-impl: CPython
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -81,6 +84,9 @@ jobs:
         - python-version: "3.11"
           python-release: v3.11
           python-impl: CPython
+        - python-version: "3.12"
+          python-release: v3.12
+          python-impl: CPython
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -132,6 +138,9 @@ jobs:
           python-impl: CPython
         - python-version: "3.11"
           python-release: v3.11
+          python-impl: CPython
+        - python-version: "3.12"
+          python-release: v3.12
           python-impl: CPython
     steps:
     - name: Checkout code

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Rust
     Topic :: Documentation :: Sphinx
     Topic :: Software Development :: Documentation


### PR DESCRIPTION
This updates github publish and test worklows and package metadata to add support for python 3.12. This would allow publishing a new release (presumably 0.2.2) with wheels for python 3.12.

Fixes #4.